### PR TITLE
Add ability to calculate tax for completed order

### DIFF
--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -40,7 +40,7 @@ module Spree
       address = order.ship_address
 
       return false unless Spree::Avatax::Config.tax_calculation
-      return false unless %w(cart payment).include?(order.state)
+      return false unless %w(cart payment complete).include?(order.state)
       return false if address.nil?
       return false unless calculable.zone.include?(address)
 


### PR DESCRIPTION
Through manual order tool, order can get modified after it is completed for various reasons.
We need to recalculate taxes for order in such scenario so add that state in allowed states here.