### PR TITLE
Fix tax on shipping cost

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -55,7 +55,7 @@ module SolidusAvataxCertified
         number: "#{shipment.id}-FR",
         itemCode: shipment.shipping_method.name,
         quantity: 1,
-        amount: shipment.discounted_amount.to_f,
+        amount: shipment_cost(shipment),
         description: 'Shipping Charge',
         taxCode: shipment.shipping_method_tax_code,
         discounted: false,
@@ -153,6 +153,11 @@ module SolidusAvataxCertified
 
     def tax_included_in_price?(item)
       !!order.tax_zone.tax_rates.where(tax_category: item.tax_category).try(:first)&.included_in_price
+    end
+
+    def shipment_cost(shipment)
+      cost = shipment.discounted_amount.to_f
+      cost.positive? ? order.taxable_shipping_total.to_f : 0
     end
   end
 end


### PR DESCRIPTION
We allow store credits to be used against shipping cost
(if their amount is greater than cart discounted total)
But they are used as a payment source and not as a promotion
so their used value is not stored in `promo_total` in shipments
Hence `discounted_amount` returns wrong value for taxable shipping cost total
This change (which uses a method added on spree order in main app: https://github.com/sdtechdev/spree-jiffyshirts/pull/9482/commits/41ff9b2183f16f89714f4244312d02030f1bde7f)
fixes that issue and uses correct amount for tax calculation