### PR TITLE
Jiffy custom changes on top of Avatax branch "v1.0-v2.0"

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-branch = ENV.fetch('SOLIDUS_BRANCH', 'v2.0')
+branch = ENV.fetch('SOLIDUS_BRANCH', 'v2.0.3')
 gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_auth_devise"
 gem 'avatax-ruby'

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -28,7 +28,7 @@ module SolidusAvataxCertified
         itemCode: line_item.variant.sku,
         quantity: line_item.quantity,
         amount: line_item.amount.to_f,
-        discounted: discounted?(line_item),
+        discounted: true,
         taxIncluded: tax_included_in_price?(line_item),
         addresses: {
           shipFrom: get_stock_location(line_item),
@@ -149,10 +149,6 @@ module SolidusAvataxCertified
 
     def business_id_no
       order.user.try(:vat_id)
-    end
-
-    def discounted?(line_item)
-      line_item.adjustments.promotion.eligible.any? || order.adjustments.promotion.eligible.any?
     end
 
     def tax_included_in_price?(item)

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -55,7 +55,7 @@ module SolidusAvataxCertified
         number: "#{shipment.id}-FR",
         itemCode: shipment.shipping_method.name,
         quantity: 1,
-        amount: shipment.discounted_amount.to_f,
+        amount: shipment_cost(shipment),
         description: 'Shipping Charge',
         taxCode: shipment.shipping_method_tax_code,
         discounted: false,
@@ -153,6 +153,11 @@ module SolidusAvataxCertified
 
     def tax_included_in_price?(item)
       !!order.tax_zone.tax_rates.where(tax_category: item.tax_category).try(:first)&.included_in_price
+    end
+
+    def shipment_cost(shipment)
+      cost = shipment.discounted_amount.to_f
+      cost.positive? ? order.taxable_shipping_total.to_f : 0
     end
   end
 end

--- a/app/models/solidus_avatax_certified/request/get_tax.rb
+++ b/app/models/solidus_avatax_certified/request/get_tax.rb
@@ -6,7 +6,7 @@ module SolidusAvataxCertified
           createTransactionModel: {
             code: order.number,
             date: doc_date,
-            discount: order.all_adjustments.promotion.eligible.sum(:amount).abs.to_s,
+            discount: order.discount_for_tax.to_s,
             commit: @commit,
             type: @doc_type ? @doc_type : 'SalesOrder',
             lines: sales_lines

--- a/app/models/spree/avatax_configuration.rb
+++ b/app/models/spree/avatax_configuration.rb
@@ -23,14 +23,10 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
   end
 
   def self.environment
-    # if Rails.env.production?
-    #   :production
-    # else
-    #   :sandbox
-    # end
-
-    # currently we don't have :sandbox account, but separate :production account being used as
-    # sandbox so it has API url similar to prod hence we need this change
-    :production
+    if Rails.env.production?
+      :production
+    else
+      :sandbox
+    end
   end
 end

--- a/app/models/spree/avatax_configuration.rb
+++ b/app/models/spree/avatax_configuration.rb
@@ -23,10 +23,14 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
   end
 
   def self.environment
-    if Rails.env.production?
-      :production
-    else
-      :sandbox
-    end
+    # if Rails.env.production?
+    #   :production
+    # else
+    #   :sandbox
+    # end
+
+    # currently we don't have :sandbox account, but separate :production account being used as
+    # sandbox so it has API url similar to prod hence we need this change
+    :production
   end
 end

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -40,7 +40,7 @@ module Spree
       address = order.ship_address
 
       return false unless Spree::Avatax::Config.tax_calculation
-      return false unless %w(cart payment).include?(order.state)
+      return false unless %w(cart payment complete).include?(order.state)
       return false if address.nil?
       return false unless calculable.zone.include?(address)
 

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -40,7 +40,7 @@ module Spree
       address = order.ship_address
 
       return false unless Spree::Avatax::Config.tax_calculation
-      return false if %w(address cart).include?(order.state)
+      return false unless %w(cart payment).include?(order.state)
       return false if address.nil?
       return false unless calculable.zone.include?(address)
 

--- a/lib/solidus_avatax_certified/seeder.rb
+++ b/lib/solidus_avatax_certified/seeder.rb
@@ -7,7 +7,7 @@ module SolidusAvataxCertified
         create_tax
         add_tax_category_to_shipping_methods
         add_tax_category_to_products
-        populate_default_stock_location
+        # populate_default_stock_location
 
         puts "***** SOLIDUS AVATAX CERTIFIED *****"
         puts ""

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus_core", [">= 1.0.0", "< 2.1.0"]
-  s.add_dependency "json", "~> 1.8"
+  s.add_dependency "json", "~> 2.1"
   s.add_dependency "avatax-ruby"
   s.add_dependency "logging", "~> 2.0"
   s.add_dependency "solidus_support"


### PR DESCRIPTION
These are the changes we did to get taxes working on top of the Avatax gem branch for Solidus version 2.0.3 which we were using at the time of integration 

Creating this PR to preserve these changes here. 
It won't be merged. These changes will now be done on top of gem's branch "v2.1-v2.2" which we need to use for Solidus version 2.1.1