### PR TITLE
Migrate jiffy custom changes after solidus upgrade

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -32,7 +32,7 @@ module SolidusAvataxCertified
         quantity: line_item.quantity,
         amount: line_item.amount.to_f,
         discounted: true,
-        taxIncluded: tax_included_in_price?(line_item),
+        taxIncluded: false,
         addresses: {
           shipFrom: get_stock_location(line_item),
           shipTo: ship_to
@@ -62,7 +62,7 @@ module SolidusAvataxCertified
         description: 'Shipping Charge',
         taxCode: shipment.shipping_method_tax_code,
         discounted: false,
-        taxIncluded: tax_included_in_price?(shipment),
+        taxIncluded: false,
         addresses: {
           shipFrom: shipment.stock_location.to_avatax_hash,
           shipTo: ship_to
@@ -152,10 +152,6 @@ module SolidusAvataxCertified
 
     def business_id_no
       order.user.try(:vat_id)
-    end
-
-    def tax_included_in_price?(item)
-      !!rates_for_item(item).try(:first)&.included_in_price
     end
 
     def shipment_cost(shipment)

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -31,7 +31,7 @@ module SolidusAvataxCertified
         itemCode: line_item.variant.sku,
         quantity: line_item.quantity,
         amount: line_item.amount.to_f,
-        discounted: discounted?(line_item),
+        discounted: true,
         taxIncluded: tax_included_in_price?(line_item),
         addresses: {
           shipFrom: get_stock_location(line_item),
@@ -152,10 +152,6 @@ module SolidusAvataxCertified
 
     def business_id_no
       order.user.try(:vat_id)
-    end
-
-    def discounted?(line_item)
-      line_item.adjustments.promotion.eligible.any? || order.adjustments.promotion.eligible.any?
     end
 
     def tax_included_in_price?(item)

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -58,7 +58,7 @@ module SolidusAvataxCertified
         number: "#{shipment.id}-FR",
         itemCode: shipment.shipping_method.name,
         quantity: 1,
-        amount: shipment.discounted_amount.to_f,
+        amount: shipment_cost(shipment),
         description: 'Shipping Charge',
         taxCode: shipment.shipping_method_tax_code,
         discounted: false,
@@ -156,6 +156,11 @@ module SolidusAvataxCertified
 
     def tax_included_in_price?(item)
       !!rates_for_item(item).try(:first)&.included_in_price
+    end
+
+    def shipment_cost(shipment)
+      cost = shipment.discounted_amount.to_f
+      cost.positive? ? order.taxable_shipping_total.to_f : 0
     end
   end
 end

--- a/app/models/solidus_avatax_certified/request/get_tax.rb
+++ b/app/models/solidus_avatax_certified/request/get_tax.rb
@@ -6,7 +6,7 @@ module SolidusAvataxCertified
           createTransactionModel: {
             code: order.number,
             date: doc_date,
-            discount: order.all_adjustments.promotion.eligible.sum(:amount).abs.to_s,
+            discount: order.discount_for_tax.to_s,
             commit: @commit,
             type: @doc_type ? @doc_type : 'SalesOrder',
             lines: sales_lines

--- a/lib/solidus_avatax_certified/seeder.rb
+++ b/lib/solidus_avatax_certified/seeder.rb
@@ -7,7 +7,7 @@ module SolidusAvataxCertified
         create_tax
         add_tax_category_to_shipping_methods
         add_tax_category_to_products
-        populate_default_stock_location
+        # populate_default_stock_location
 
         puts "***** SOLIDUS AVATAX CERTIFIED *****"
         puts ""

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.requirements << "none"
 
   s.add_dependency "solidus_core", [">= 2.1.0", "< 2.3.0"]
-  s.add_dependency "json", "~> 1.8"
+  s.add_dependency "json", "~> 2.1"
   s.add_dependency "avatax-ruby"
   s.add_dependency "logging", "~> 2.0"
   s.add_dependency "solidus_support"


### PR DESCRIPTION
These changes were done during original integration (see https://github.com/sdtechdev/solidus_avatax_certified/pull/5)

We need to bring them to the new branch we will be using which supports Solidus 2.1.1

`jiffy-v2.1-v2.2` currently is copy of `v2.1-v2.2`
we will use `jiffy-v2.1-v2.2` in our app