### PR TITLE
Fix tax calculation after order is complete

### DIFF
--- a/app/models/solidus_avatax_certified/order_adjuster.rb
+++ b/app/models/solidus_avatax_certified/order_adjuster.rb
@@ -6,6 +6,10 @@ module SolidusAvataxCertified
         return (order.line_items + order.shipments)
       end
 
+      if order.complete? && !order.additional_tax_total.positive?
+        return (order.line_items + order.shipments)
+      end
+
       super
     end
   end


### PR DESCRIPTION
Order could get updated after it is complete for various reasons
If the order did not have taxes originally, the update should not add taxes

Hence- If order is complete and tax is currently zero, do not calculate taxes
(do not do API call as well)

just do what we do in cart - ignore tax calculation