### PR TITLE
Use forked version of avatax ruby gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source "https://rubygems.org"
 branch = 'v2.1'
 gem "solidus", github: "solidusio/solidus", branch: branch
 gem "solidus_auth_devise", github: "solidusio/solidus_auth_devise"
-gem 'avatax-ruby'
+gem 'avatax-ruby', github: 'sdtechdev/avatax', branch: 'jiffy'
 
 group :test, :development do
   gem "pry"


### PR DESCRIPTION
We are gonna add more things in `avatax-ruby` gem to support exemption
certificates etc. hence we need this