### PR TITLE
Updates related to tax calculation and API call caching

### DIFF
--- a/app/models/spree/address_decorator.rb
+++ b/app/models/spree/address_decorator.rb
@@ -12,4 +12,11 @@ Spree::Address.class_eval do
   def self.validation_enabled_countries
     Spree::Avatax::Config.address_validation_enabled_countries
   end
+
+  def avatax_cache_key
+    key = ['Spree::Address']
+    key << address1&.downcase
+    key << zipcode
+    key.compact.join('-')
+  end
 end

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -41,7 +41,7 @@ module Spree
       address = order.ship_address
 
       return false unless Spree::Avatax::Config.tax_calculation
-      return false if %w(address cart delivery).include?(order.state)
+      return false unless order.payment?
       return false if address.nil?
       return false unless calculable.zone.include?(address)
 

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -61,7 +61,7 @@ module Spree
 
     def long_cache_key(order)
       key = order.avatax_cache_key
-      key << (order.ship_address.try(:cache_key) || order.bill_address.try(:cache_key)).to_s
+      key << order.ship_address.avatax_cache_key if order.ship_address
       order.line_items.each do |line_item|
         key << line_item.avatax_cache_key
       end

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -49,7 +49,7 @@ module Spree
     end
 
     def get_avalara_response(order)
-      Rails.cache.fetch(cache_key(order), time_to_idle: 5.minutes) do
+      Rails.cache.fetch(cache_key(order), time_to_idle: 15.minutes) do
         if order.can_commit?
           order.avalara_capture_finalize
         else

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -15,7 +15,7 @@ Spree::LineItem.class_eval do
     key << self.id
     key << self.quantity
     key << self.price
-    key << self.promo_total
+    key << self.discounted_total
     key.join('-')
   end
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -53,7 +53,7 @@ Spree::Order.class_eval do
   def avatax_cache_key
     key = ['Spree::Order']
     key << self.number
-    key << self.promo_total
+    key << self.item_total
     key.join('-')
   end
 

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -2,10 +2,8 @@ Spree::Shipment.class_eval do
 
   def avatax_cache_key
     key = ['Spree::Shipment']
-    key << self.id
-    key << self.cost
-    key << self.stock_location.try(:cache_key)
-    key << self.promo_total
+    key << cost
+    key << stock_location&.admin_name.to_s
     key.join('-')
   end
 


### PR DESCRIPTION
- Calculate tax only in `payment` state (basically avoid recalculation after order is placed)
- Fix cache key to work with our system (ensure it bursts when needed and not otherwise)
- Cache for 15 minutes
