### PR TITLE
Fix retrieving shipping tax from cached Avalara response

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -25,7 +25,7 @@ module SolidusAvataxCertified
 
     def item_line(line_item)
       {
-        number: "#{line_item.id}-LI",
+        number: "#{line_item.avatax_id}-LI",
         description: line_item.name[0..255],
         taxCode: line_item.tax_category.try(:tax_code) || '',
         itemCode: line_item.variant.sku,
@@ -55,7 +55,7 @@ module SolidusAvataxCertified
 
     def shipment_line(shipment)
       {
-        number: "#{shipment.id}-FR",
+        number: "#{shipment.avatax_id}-FR",
         itemCode: shipment.shipping_method.name,
         quantity: 1,
         amount: shipment_cost(shipment),

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -89,7 +89,7 @@ module Spree
       return 0 if avalara_response[:totalTax] == 0.0
 
       avalara_response['lines'].each do |line|
-        if line['lineNumber'] == "#{item.id}-#{item.avatax_line_code}"
+        if line['lineNumber'] == "#{item.avatax_id}-#{item.avatax_line_code}"
           return line['taxCalculated']
         end
       end

--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -10,6 +10,10 @@ Spree::LineItem.class_eval do
     }
   end
 
+  def avatax_id
+    id
+  end
+
   def avatax_cache_key
     key = ['Spree::LineItem']
     key << self.id

--- a/app/models/spree/shipment_decorator.rb
+++ b/app/models/spree/shipment_decorator.rb
@@ -1,4 +1,7 @@
 Spree::Shipment.class_eval do
+  def avatax_id
+    stock_location_id
+  end
 
   def avatax_cache_key
     key = ['Spree::Shipment']


### PR DESCRIPTION
We removed shipment id from cached response to reduce API calls to Avalara
But because of that - if shipment gets recreated without any other change to order (eg. reloading checkout page) - we were losing the shipping tax adjustment on deleted shipment as it was not properly getting transferred to new shipment
Now after changing identifier of shipment from id to stock location id, we can do that correctly and not reduce shipping tax from order incorrectly