### PR TITLE
Enable tax recalculation in certain completed orders

### DIFF
--- a/app/models/solidus_avatax_certified/order_adjuster.rb
+++ b/app/models/solidus_avatax_certified/order_adjuster.rb
@@ -6,10 +6,6 @@ module SolidusAvataxCertified
         return (order.line_items + order.shipments)
       end
 
-      if order.complete? && !order.additional_tax_total.positive?
-        return (order.line_items + order.shipments)
-      end
-
       super
     end
   end

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -11,7 +11,7 @@ module Spree
     def compute_shipment_or_line_item(item)
       order = item.order
 
-      if can_calculate_tax?(order)
+      if can_calculate_tax?(order, item)
         avalara_response = get_avalara_response(order)
         tax_for_item(item, avalara_response)
       else
@@ -36,12 +36,12 @@ module Spree
       end
     end
 
-
-    def can_calculate_tax?(order)
+    def can_calculate_tax?(order, item = nil)
       address = order.ship_address
 
       return false unless Spree::Avatax::Config.tax_calculation
-      return false unless order.payment?
+      return false unless %w[payment complete].include?(order.state)
+      return false if order.completed? && item && order.completed_at >= item.created_at
       return false if address.nil?
       return false unless calculable.zone.include?(address)
 


### PR DESCRIPTION
Order can get recreated (line items and shipments) once it is complete
(e.g. Order Change Tool recreates order completely and it is in complete state with line items and shipments having 0 tax even if order had taxes originally)

This change enables us to recalculate taxes in such cases