### PR TITLE
Fix document date for Avalara transactions

### DIFF
--- a/app/models/solidus_avatax_certified/request/get_tax.rb
+++ b/app/models/solidus_avatax_certified/request/get_tax.rb
@@ -16,6 +16,22 @@ module SolidusAvataxCertified
 
       protected
 
+      def base_tax_hash
+        super.merge(tax_override)
+      end
+
+      def tax_override
+        return {} unless order.completed?
+
+        {
+          taxOverride: {
+            type: 'TaxDate',
+            reason: 'Order Completion Time',
+            taxDate: order.completed_at.strftime('%F')
+          }
+        }
+      end
+
       def doc_date
         date = order.respond_to?(:doc_date) ? order.doc_date : Date.current
 

--- a/app/models/solidus_avatax_certified/request/get_tax.rb
+++ b/app/models/solidus_avatax_certified/request/get_tax.rb
@@ -17,7 +17,9 @@ module SolidusAvataxCertified
       protected
 
       def doc_date
-        order.completed? ? order.completed_at.strftime('%F') : Date.today.strftime('%F')
+        date = order.respond_to?(:doc_date) ? order.doc_date : Date.current
+
+        date.strftime('%F')
       end
     end
   end

--- a/app/models/solidus_avatax_certified/request/return_tax.rb
+++ b/app/models/solidus_avatax_certified/request/return_tax.rb
@@ -12,7 +12,7 @@ module SolidusAvataxCertified
         {
           createTransactionModel: {
             code: order.number.to_s + '.' + @refund.id.to_s,
-            date: Date.today.strftime('%F'),
+            date: doc_date,
             commit: @commit,
             type: @doc_type ? @doc_type : 'ReturnOrder',
             lines: sales_lines
@@ -23,7 +23,7 @@ module SolidusAvataxCertified
       protected
 
       def doc_date
-        Date.today.strftime('%F')
+        Date.current.strftime('%F')
       end
 
       def base_tax_hash


### PR DESCRIPTION
It should not be order completed date - but the date when we capture payment which could be upto few days later compared to order completed date - or refund issue date in case of refunds - in correct time zone