### PR TITLE
Rectify avatax_cache_key for order

### DIFF
--- a/app/models/spree/line_item_decorator.rb
+++ b/app/models/spree/line_item_decorator.rb
@@ -20,6 +20,7 @@ Spree::LineItem.class_eval do
     key << self.quantity
     key << self.price
     key << self.discounted_total
+    key << self.promo_total
     key.join('-')
   end
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -54,6 +54,7 @@ Spree::Order.class_eval do
     key = ['Spree::Order']
     key << self.number
     key << self.item_total
+    key << self.promo_total
     key.join('-')
   end
 

--- a/app/models/spree/order_decorator.rb
+++ b/app/models/spree/order_decorator.rb
@@ -55,6 +55,7 @@ Spree::Order.class_eval do
     key << self.number
     key << self.item_total
     key << self.promo_total
+    key << self.discount_for_tax
     key.join('-')
   end
 


### PR DESCRIPTION
[Jira](https://dekeo.atlassian.net/browse/ALPHA-482)
Currently we just have order's `item_total` in cache key, but its the same even after applying promo code. So tax remains unchanged(cached for 15 mins) even after applying promo
code. We should have `self.discount_for_tax` as part of the key to burst the cache if discount value is changed.