### PR TITLE
Migrate jiffy custom changes after solidus upgrade

### DIFF
--- a/app/decorators/models/solidus_avatax_certified/spree/address_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/address_decorator.rb
@@ -22,6 +22,13 @@ module SolidusAvataxCertified
         ::Spree::Address.validation_enabled_countries.include?(country.try(:name))
       end
 
+      def avatax_cache_key
+        key = ['Spree::Address']
+        key << address1&.downcase
+        key << zipcode
+        key.compact.join('-')
+      end
+
       ::Spree::Address.prepend self
     end
   end

--- a/app/decorators/models/solidus_avatax_certified/spree/line_item_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/line_item_decorator.rb
@@ -19,12 +19,17 @@ module SolidusAvataxCertified
         key << id
         key << quantity
         key << price
+        key << discounted_total
         key << promo_total
         key.join('-')
       end
 
       def avatax_line_code
         'LI'
+      end
+
+      def avatax_id
+        id
       end
 
       ::Spree::LineItem.prepend self

--- a/app/decorators/models/solidus_avatax_certified/spree/order_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/order_decorator.rb
@@ -59,7 +59,9 @@ module SolidusAvataxCertified
       def avatax_cache_key
         key = ['Spree::Order']
         key << number
+        key << item_total
         key << promo_total
+        key << discount_for_tax
         key.join('-')
       end
 

--- a/app/decorators/models/solidus_avatax_certified/spree/shipment_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/shipment_decorator.rb
@@ -3,11 +3,14 @@
 module SolidusAvataxCertified
   module Spree
     module ShipmentDecorator
+      def avatax_id
+        stock_location_id
+      end
+
       def avatax_cache_key
         key = ['Spree::Shipment']
-        key << id
         key << cost
-        key << stock_location.try(:cache_key)
+        key << stock_location&.admin_name.to_s
         key << promo_total
         key.join('-')
       end

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -33,8 +33,8 @@ module SolidusAvataxCertified
         itemCode: truncateLine(line_item.variant.sku),
         quantity: line_item.quantity,
         amount: line_item.amount.to_f,
-        discounted: discounted?(line_item),
-        taxIncluded: tax_included_in_price?(line_item),
+        discounted: true,
+        taxIncluded: false,
         addresses: {
           shipFrom: get_stock_location(line_item),
           shipTo: ship_to
@@ -64,8 +64,8 @@ module SolidusAvataxCertified
         amount: shipment.total_before_tax.to_f,
         description: 'Shipping Charge',
         taxCode: shipment.shipping_method_tax_code,
-        discounted: !shipment.promo_total.zero?,
-        taxIncluded: tax_included_in_price?(shipment),
+        discounted: false,
+        taxIncluded: false,
         addresses: {
           shipFrom: shipment.stock_location.to_avatax_hash,
           shipTo: ship_to
@@ -160,16 +160,6 @@ module SolidusAvataxCertified
 
     def business_id_no
       order.user.try(:vat_id)
-    end
-
-    def discounted?(line_item)
-      line_item.adjustments.promotion.eligible.any? ||
-        order.adjustments.promotion.eligible.any? ||
-        order.adjustments.where('amount < 0').where(source: nil).eligible.any?
-    end
-
-    def tax_included_in_price?(item)
-      !!rates_for_item(item).try(:first)&.included_in_price
     end
   end
 end

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -63,7 +63,7 @@ module SolidusAvataxCertified
         number: "#{shipment.avatax_id}-FR",
         itemCode: truncateLine(shipment.shipping_method.name),
         quantity: 1,
-        amount: shipment.total_before_tax.to_f,
+        amount: shipment_cost(shipment),
         description: 'Shipping Charge',
         taxCode: shipment.shipping_method_tax_code,
         discounted: false,
@@ -188,6 +188,11 @@ module SolidusAvataxCertified
       else
         {}
       end
+    end
+
+    def shipment_cost(shipment)
+      cost = shipment.discounted_amount.to_f
+      cost.positive? ? order.taxable_shipping_total.to_f : 0
     end
   end
 end

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -27,7 +27,7 @@ module SolidusAvataxCertified
 
     def item_line(line_item)
       {
-        number: "#{line_item.id}-LI",
+        number: "#{line_item.avatax_id}-LI",
         description: line_item.name[0..255],
         taxCode: line_item.tax_category.try(:tax_code) || '',
         itemCode: truncateLine(line_item.variant.sku),
@@ -58,7 +58,7 @@ module SolidusAvataxCertified
 
     def shipment_line(shipment)
       {
-        number: "#{shipment.id}-FR",
+        number: "#{shipment.avatax_id}-FR",
         itemCode: truncateLine(shipment.shipping_method.name),
         quantity: 1,
         amount: shipment.total_before_tax.to_f,

--- a/app/models/solidus_avatax_certified/request/base.rb
+++ b/app/models/solidus_avatax_certified/request/base.rb
@@ -39,7 +39,7 @@ module SolidusAvataxCertified
       end
 
       def company_code
-        @company_code ||= ::Spree::Avatax::Config.company_code
+        order.store.avatax_config['company_code'] || Spree::Avatax::Config.company_code
       end
 
       def business_id_no

--- a/app/models/solidus_avatax_certified/request/get_tax.rb
+++ b/app/models/solidus_avatax_certified/request/get_tax.rb
@@ -35,7 +35,9 @@ module SolidusAvataxCertified
       end
 
       def doc_date
-        order.completed? ? order.completed_at.strftime('%F') : Date.today.strftime('%F')
+        date = order.respond_to?(:doc_date) ? order.doc_date : Date.current
+
+        date.strftime('%F')
       end
     end
   end

--- a/app/models/solidus_avatax_certified/request/get_tax.rb
+++ b/app/models/solidus_avatax_certified/request/get_tax.rb
@@ -4,14 +4,11 @@ module SolidusAvataxCertified
   module Request
     class GetTax < SolidusAvataxCertified::Request::Base
       def generate
-        promotion_discount = order.all_adjustments.promotion.eligible.sum(:amount).abs
-        manual_discount = order.all_adjustments.where('amount < 0').where(source: nil).eligible.sum(:amount).abs
-
         {
           createTransactionModel: {
             code: order.number,
             date: doc_date,
-            discount: (promotion_discount + manual_discount).to_s,
+            discount: order.discount_for_tax.to_s,
             commit: @commit,
             type: @doc_type || 'SalesOrder',
             lines: sales_lines

--- a/app/models/solidus_avatax_certified/request/get_tax.rb
+++ b/app/models/solidus_avatax_certified/request/get_tax.rb
@@ -18,6 +18,22 @@ module SolidusAvataxCertified
 
       protected
 
+      def base_tax_hash
+        super.merge(tax_override)
+      end
+
+      def tax_override
+        return {} unless order.completed?
+
+        {
+          taxOverride: {
+            type: 'TaxDate',
+            reason: 'Order Completion Time',
+            taxDate: order.completed_at.strftime('%F')
+          }
+        }
+      end
+
       def doc_date
         order.completed? ? order.completed_at.strftime('%F') : Date.today.strftime('%F')
       end

--- a/app/models/solidus_avatax_certified/request/return_tax.rb
+++ b/app/models/solidus_avatax_certified/request/return_tax.rb
@@ -13,7 +13,7 @@ module SolidusAvataxCertified
         {
           createTransactionModel: {
             code: order.number.to_s + '.' + @refund.id.to_s,
-            date: Date.today.strftime('%F'),
+            date: doc_date,
             commit: @commit,
             type: @doc_type || 'ReturnOrder',
             lines: sales_lines
@@ -24,7 +24,7 @@ module SolidusAvataxCertified
       protected
 
       def doc_date
-        Date.today.strftime('%F')
+        Date.current.strftime('%F')
       end
 
       def base_tax_hash

--- a/app/models/solidus_avatax_certified/request/return_tax.rb
+++ b/app/models/solidus_avatax_certified/request/return_tax.rb
@@ -6,6 +6,7 @@ module SolidusAvataxCertified
       def initialize(order, opts = {})
         super
         @refund = opts[:refund]
+        @override_tax = opts[:override_tax]
       end
 
       def generate
@@ -31,6 +32,8 @@ module SolidusAvataxCertified
       end
 
       def tax_override
+        return {} if @override_tax.present?
+
         {
           taxOverride: {
             type: 'TaxDate',
@@ -41,7 +44,7 @@ module SolidusAvataxCertified
       end
 
       def sales_lines
-        @sales_lines ||= SolidusAvataxCertified::Line.new(order, @doc_type, @refund).lines
+        @sales_lines ||= SolidusAvataxCertified::Line.new(order, @doc_type, @refund, @override_tax).lines
       end
     end
   end

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -10,10 +10,10 @@ module Spree
       post_order_to_avalara(false, 'SalesOrder')
     end
 
-    def commit_avatax(invoice_dt = nil, refund = nil)
+    def commit_avatax(invoice_dt = nil, refund = nil, override_tax = nil)
       if tax_calculation_enabled?
         if %w(ReturnInvoice ReturnOrder).include?(invoice_dt)
-          post_return_to_avalara(false, invoice_dt, refund)
+          post_return_to_avalara(false, invoice_dt, refund, override_tax)
         else
           post_order_to_avalara(false, invoice_dt)
         end
@@ -22,11 +22,11 @@ module Spree
       end
     end
 
-    def commit_avatax_final(invoice_dt = nil, refund = nil)
+    def commit_avatax_final(invoice_dt = nil, refund = nil, override_tax = nil)
       if document_committing_enabled?
         if tax_calculation_enabled?
           if %w(ReturnInvoice ReturnOrder).include?(invoice_dt)
-            post_return_to_avalara(true, invoice_dt, refund)
+            post_return_to_avalara(true, invoice_dt, refund, override_tax)
           else
             post_order_to_avalara(true, invoice_dt)
           end

--- a/app/models/spree/avatax_configuration.rb
+++ b/app/models/spree/avatax_configuration.rb
@@ -15,6 +15,9 @@ class Spree::AvataxConfiguration < Spree::Preferences::Configuration
   preference :refuse_checkout_address_validation_error, :boolean, default: false
   preference :customer_can_validate, :boolean, default: false
   preference :raise_exceptions, :boolean, default: false
+  preference :connection_retry_limit, :integer, default: 1
+  preference :connection_timout, :integer, default: 20
+  preference :connection_retry_exception, :array, default: nil
 
   def self.boolean_preferences
     %w(tax_calculation document_commit log log_to_stdout address_validation refuse_checkout_address_validation_error customer_can_validate raise_exceptions)

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -53,7 +53,7 @@ module Spree
     end
 
     def get_avalara_response(order)
-      Rails.cache.fetch(cache_key(order), time_to_idle: 5.minutes) do
+      Rails.cache.fetch(cache_key(order), time_to_idle: 15.minutes) do
         if order.can_commit?
           order.avalara_capture_finalize
         else
@@ -64,7 +64,8 @@ module Spree
 
     def long_cache_key(order)
       key = order.avatax_cache_key
-      key << order.tax_address.try(:cache_key)
+      key << order.ship_address.avatax_cache_key if order.ship_address
+
       order.line_items.each do |line_item|
         key << line_item.avatax_cache_key
       end
@@ -92,7 +93,7 @@ module Spree
       return 0 if avalara_response['totalTax'] == 0.0
 
       avalara_response['lines'].each do |line|
-        if line['lineNumber'] == "#{item.id}-#{item.avatax_line_code}"
+        if line['lineNumber'] == "#{item.avatax_id}-#{item.avatax_line_code}"
           return line['taxCalculated']
         end
       end

--- a/app/models/tax_svc.rb
+++ b/app/models/tax_svc.rb
@@ -91,12 +91,28 @@ class TaxSvc
     Spree::Avatax::Config.environment
   end
 
+  def connection_retry_limit
+    Spree::Avatax::Config.connection_retry_limit
+  end
+
+  def connection_retry_exception
+    Spree::Avatax::Config.connection_retry_exception
+  end
+
+  def connection_timout
+    Spree::Avatax::Config.connection_timout
+  end
+
+
   def client
     @client ||= Avatax::Client.new(
       username: account_number,
       password: license_key,
       env: environment,
-      headers: AVATAX_HEADERS
+      headers: AVATAX_HEADERS,
+      retry: connection_retry_limit,
+      retry_exceptions: connection_retry_exception,
+      timeout: connection_timout
     )
   end
 

--- a/lib/solidus_avatax_certified/seeder.rb
+++ b/lib/solidus_avatax_certified/seeder.rb
@@ -8,7 +8,7 @@ module SolidusAvataxCertified
         create_tax
         add_tax_category_to_shipping_methods
         add_tax_category_to_products
-        populate_default_stock_location
+        # populate_default_stock_location
 
         puts "***** SOLIDUS AVATAX CERTIFIED *****"
         puts ""

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -23,9 +23,9 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   solidus_version = ['>= 2.3.0', '< 3.0.0']
-  s.add_dependency 'avatax-ruby'
+  s.add_dependency 'avatax-ruby', github: 'sdtechdev/avatax', branch: 'jiffy'
   s.add_dependency 'deface', '~> 1.5'
-  s.add_dependency 'json', '~> 2.0'
+  s.add_dependency 'json', '~> 2.1'
   s.add_dependency 'logging', '~> 2.0'
   s.add_dependency 'solidus', solidus_version
   s.add_dependency 'solidus_support'


### PR DESCRIPTION
We need to bring our custom changes to the new branch we will be using which supports Solidus `2.3.1`

`jiffy-v2.3` currently is copy of `master` (at this moment)
we will use `jiffy-v2.3` in our app

---

custom changes include:
- gem updates
- faraday timeout customizations
- caching fix
- reduce tax calculation occurrences 
- fix for order discounts
- fir tax refund tracking in avalara
- fix for shipping tax
- fix document tracking date
- multiple store support
etc