### PR TITLE
Fix Avatax gem dependency

### DIFF
--- a/app/models/solidus_avatax_certified/request/base.rb
+++ b/app/models/solidus_avatax_certified/request/base.rb
@@ -39,7 +39,7 @@ module SolidusAvataxCertified
       end
 
       def company_code
-        order.store.avatax_config['company_code'] || Spree::Avatax::Config.company_code
+        order.store.avatax_config['company_code'] || ::Spree::Avatax::Config.company_code
       end
 
       def business_id_no

--- a/app/models/spree/avalara_transaction.rb
+++ b/app/models/spree/avalara_transaction.rb
@@ -79,11 +79,11 @@ module Spree
     end
 
     def document_committing_enabled?
-      Spree::Avatax::Config.document_commit
+      ::Spree::Avatax::Config.document_commit
     end
 
     def tax_calculation_enabled?
-      Spree::Avatax::Config.tax_calculation
+      ::Spree::Avatax::Config.tax_calculation
     end
 
     def logger

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -44,7 +44,7 @@ module Spree
     def can_calculate_tax?(order, item)
       address = order.tax_address
 
-      return false unless Spree::Avatax::Config.tax_calculation
+      return false unless ::Spree::Avatax::Config.tax_calculation
       return false unless %w[payment complete].include?(order.state)
       return false if order.completed? && item && order.completed_at >= item.created_at && !order.tax_error?
       return false if address.nil?

--- a/app/models/tax_svc.rb
+++ b/app/models/tax_svc.rb
@@ -68,39 +68,39 @@ class TaxSvc
   private
 
   def tax_calculation_enabled?
-    Spree::Avatax::Config.tax_calculation
+    ::Spree::Avatax::Config.tax_calculation
   end
 
   def account_number
-    Spree::Avatax::Config.account
+    ::Spree::Avatax::Config.account
   end
 
   def license_key
-    Spree::Avatax::Config.license_key
+    ::Spree::Avatax::Config.license_key
   end
 
   def raise_exceptions?
-    Spree::Avatax::Config.raise_exceptions
+    ::Spree::Avatax::Config.raise_exceptions
   end
 
   def company_code
-    Spree::Avatax::Config.company_code
+    ::Spree::Avatax::Config.company_code
   end
 
   def environment
-    Spree::Avatax::Config.environment
+    ::Spree::Avatax::Config.environment
   end
 
   def connection_retry_limit
-    Spree::Avatax::Config.connection_retry_limit
+    ::Spree::Avatax::Config.connection_retry_limit
   end
 
   def connection_retry_exception
-    Spree::Avatax::Config.connection_retry_exception
+    ::Spree::Avatax::Config.connection_retry_exception
   end
 
   def connection_timout
-    Spree::Avatax::Config.connection_timout
+    ::Spree::Avatax::Config.connection_timout
   end
 
 

--- a/solidus_avatax_certified.gemspec
+++ b/solidus_avatax_certified.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.requirements << 'none'
 
   solidus_version = ['>= 2.3.0', '< 3.0.0']
-  s.add_dependency 'avatax-ruby', github: 'sdtechdev/avatax', branch: 'jiffy'
+  s.add_dependency 'avatax-ruby'
   s.add_dependency 'deface', '~> 1.5'
   s.add_dependency 'json', '~> 2.1'
   s.add_dependency 'logging', '~> 2.0'


### PR DESCRIPTION
We can't specify a github branch like that in a gemspec file
Hence need to remove it completely
We already have this branch mentioned in main repo's Gemfile currently
So removing it doesn't matter and we still get to use the custom version