### PR TITLE
Rectify conditional statement to set correct usa_ship_from address

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -211,7 +211,7 @@ module SolidusAvataxCertified
                       elsif shipment.present?
                         shipment.stock_location
                       end
-     return usa_ship_from unless stock_location || stock_location.state.abbr.in?(['MO','PA'])
+     return usa_ship_from unless stock_location && stock_location.state.abbr.in?(['MO','PA'])
 
      stock_location.to_avatax_hash
     end


### PR DESCRIPTION
In #30, condition was incorrect as we want to send `usa_ship_from` address in all cases except when stock location is one of `MO` or `PA`