### PR TITLE
Use ship_address for special states PA and MO

### DIFF
--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -211,7 +211,7 @@ module SolidusAvataxCertified
                       elsif shipment.present?
                         shipment.stock_location
                       end
-     return usa_ship_from unless stock_location && stock_location.state.abbr.in?(['MO','PA'])
+     return usa_ship_from unless stock_location && order.ship_address.state.abbr.in?(['MO','PA'])
 
      stock_location.to_avatax_hash
     end


### PR DESCRIPTION
In #30, we were sending stock location's address in shipFrom if stock location in state `PA` or `MA`. But instead we should check if order's ship_address is in state `PA` or `MA` 