### PR TITLE
Add :: before Spree::Tax

### DIFF
--- a/app/models/solidus_avatax_certified/order_adjuster.rb
+++ b/app/models/solidus_avatax_certified/order_adjuster.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module SolidusAvataxCertified
-  class OrderAdjuster < Spree::Tax::OrderAdjuster
+  class OrderAdjuster < ::Spree::Tax::OrderAdjuster
     def adjust!
       if !order.force_tax_recalculation && %w[cart address delivery].include?(order.state)
         return (order.line_items + order.shipments)


### PR DESCRIPTION
Sometimes code tries to have access to `SolidusAvataxCertified::Spree::Tax` which produces the error:
```
uninitialized constant SolidusAvataxCertified::Spree::Tax
```

This PR should fix such problems

https://dekeo.atlassian.net/browse/CORE-140