### PR TITLE
Use shipment id as identifier on shipment lines

### DIFF
--- a/app/decorators/models/solidus_avatax_certified/spree/line_item_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/line_item_decorator.rb
@@ -28,10 +28,6 @@ module SolidusAvataxCertified
         'LI'
       end
 
-      def avatax_id
-        id
-      end
-
       ::Spree::LineItem.prepend self
     end
   end

--- a/app/decorators/models/solidus_avatax_certified/spree/shipment_decorator.rb
+++ b/app/decorators/models/solidus_avatax_certified/spree/shipment_decorator.rb
@@ -3,12 +3,9 @@
 module SolidusAvataxCertified
   module Spree
     module ShipmentDecorator
-      def avatax_id
-        stock_location_id
-      end
-
       def avatax_cache_key
         key = ['Spree::Shipment']
+        key << id
         key << cost
         key << stock_location&.admin_name.to_s
         key << promo_total

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -60,7 +60,7 @@ module SolidusAvataxCertified
 
     def shipment_line(shipment)
       {
-        number: "#{shipment.avatax_id}-FR",
+        number: "#{shipment.id}-FR",
         itemCode: truncateLine(shipment.shipping_method.name),
         quantity: 1,
         amount: shipment_cost(shipment),

--- a/app/models/solidus_avatax_certified/line.rb
+++ b/app/models/solidus_avatax_certified/line.rb
@@ -29,7 +29,7 @@ module SolidusAvataxCertified
 
     def item_line(line_item)
       {
-        number: "#{line_item.avatax_id}-LI",
+        number: "#{line_item.id}-LI",
         description: line_item.name[0..255],
         taxCode: line_item.tax_category.try(:tax_code) || '',
         itemCode: truncateLine(line_item.variant.sku),

--- a/app/models/spree/calculator/avalara_transaction.rb
+++ b/app/models/spree/calculator/avalara_transaction.rb
@@ -105,7 +105,7 @@ module Spree
       return 0 if avalara_response['totalTax'] == 0.0
 
       avalara_response['lines'].each do |line|
-        if line['lineNumber'] == "#{item.avatax_id}-#{item.avatax_line_code}"
+        if line['lineNumber'] == "#{item.id}-#{item.avatax_line_code}"
           return line['taxCalculated']
         end
       end


### PR DESCRIPTION
https://dekeo.atlassian.net/browse/CHARLIE-1076

We receive "duplicate line items" error for orders that include Spree::Shipments with the same stock location.

Sample order: https://www.jiffyshirts.com/admin/orders/39515859/cart